### PR TITLE
Loading an Edited Rom No Longer Randomizes it when fully decompressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is a randomizer project build in C++ intended for use with the US version o
   - Notes are randomized within their world so all notes that were in a level should still be somewhere within that level (unless I messed it up)
   - Reward Items can only be the following items (Jiggies, Glowbos, Honeycombs, Cheato Pages, Tickets, Doubloons, and Jinjos)
 ### Known Issues
+  - No Controller on the game loading this is due to the incorrect save-type being used in the emulator to fix the issue for Project64 go to Configuration -> Config: BANJO TOOIE then switch default save type to 16-kbit eeprom.
   - Waiting long enough on the title screen will crash (I do not know what it is trying to do but just dont be there)
   - Some Items are not randomized due to difficulty in Randomizing them (Jade Snake, Dinosaur Family, Robot Fight GI Inside, Column Jiggy, Pawno, Warming the water)
   - Reward items may spawn in slightly different places than in the original game. This is due to the way jiggies are handled in the original code for rewards as opposed to everything else.

--- a/TooieRando/TooieRando.vcxproj.user
+++ b/TooieRando/TooieRando.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RESOURCE_FILE>GEDecompressor.rc</RESOURCE_FILE>
+    <RESOURCE_FILE>TooieRando.rc</RESOURCE_FILE>
     <ShowAllFiles>false</ShowAllFiles>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/TooieRando/TooieRandoDlg.cpp
+++ b/TooieRando/TooieRandoDlg.cpp
@@ -304,7 +304,7 @@ public:ScriptEdit(int newScriptIndex, int newEditType, int newAssociatedOffset, 
 }
 };
 
-
+bool Randomize = false; //Used to determine whether the decompression should trigger an event after it finishes
 CChangeLength* m_pChangeLength;  // Pointer to the dialog for extending allocated asset
 std::vector<RewardObject> RewardObjects; //Stores the object indexes that are originally reward objects
 std::vector<RandomizedObject> RandomizedObjects; //Stores the object indexes and offsets for collectable items
@@ -1230,8 +1230,11 @@ UINT TooieRandoDlg::DecompressGameThread( LPVOID pParam )
 				DecompressZLibFromTable(gameNameStr, dlg, strROMPath, dlg->syscallTableStart, dlg->syscallTableStart +0xDCC, 4, BANJOTOOIE, dlg->syscallTableStart, 0, 1, 0x10);
 				
 			}
-			TooieRandoDlg* pDlg = (TooieRandoDlg*)pParam;
-			pDlg->PostMessage(WM_USER + 1, 0, 0);
+			if (Randomize)
+			{
+				TooieRandoDlg* pDlg = (TooieRandoDlg*)pParam;
+				pDlg->PostMessage(WM_USER + 1, 0, 0);
+			}
 			return 0;
 		}
 	}
@@ -1250,6 +1253,7 @@ UINT TooieRandoDlg::DecompressGameThread( LPVOID pParam )
 
 void TooieRandoDlg::OnBnClickedDecompressgame()
 {
+	Randomize = false;
 	KillDecompressGameThread();
 	// TODO: Add your control notification handler code here
 	CString fileOpen;
@@ -2877,6 +2881,7 @@ void TooieRandoDlg::OnRclickListdecompressedfiles(NMHDR* pNMHDR, LRESULT* pResul
 
 void TooieRandoDlg::OnBnClickedDecompressgame2()
 {
+	Randomize = true;
 	KillDecompressGameThread();
 	// TODO: Add your control notification handler code here
 	CString editedRom = "output\\edited_rom.rom";


### PR DESCRIPTION
Added another disclaimer and made it so you can actually use the tool for modding or debugging purposes. If you want to manually go through the different steps of the randomization.